### PR TITLE
Image: security patches to UBI9 baseimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9@sha256:089bd3b82a78ac45c0eed231bb58bfb43bfcd0560d9bba240fc6355502c92976
+FROM registry.access.redhat.com/ubi9@sha256:c35238b35cbebe4e6c5d0f63a54e54dba41d0b425f2d101ad9f04a5e5ec100b8
 ENV SMDEV_CONTAINER_OFF=1
 RUN mkdir /var/lock/subsys
 RUN dnf makecache && \


### PR DESCRIPTION
Fixes:
* CVE-2023-28322
* CVE-2023-28321
* CVE-2023-22652
* CVE-2023-28484
* CVE-2023-29469
* CVE-2023-32681