### PR TITLE
baseimage: update ubi9 to 9.2-722.1692769367

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9@sha256:c35238b35cbebe4e6c5d0f63a54e54dba41d0b425f2d101ad9f04a5e5ec100b8
+FROM registry.access.redhat.com/ubi9@sha256:572155f3053e0267874da447743adec560458824c12d3f8acd429f781656cf33
 ENV SMDEV_CONTAINER_OFF=1
 RUN mkdir /var/lock/subsys
 RUN dnf makecache && \


### PR DESCRIPTION
fixes:
* CVE-2023-3899
* CVE-2023-34969