### PR TITLE
chore: update ubi9 baseimage to 9.2-755.1696514207

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9@sha256:351ed8b24d440c348486efd99587046e88bb966890a9207a5851d3a34a4dd346
+FROM registry.access.redhat.com/ubi9@sha256:57273341b34c7f387a6ec97bbd6aee72425d09786052f1512fb652fcd810ab4f
 ENV SMDEV_CONTAINER_OFF=1
 RUN mkdir /var/lock/subsys
 RUN dnf makecache && \


### PR DESCRIPTION
Fixes:
* CVE-2023-40217
* CVE-2023-4911
* CVE-2023-4813
* CVE-2023-4806
* CVE-2023-4527